### PR TITLE
feat: add transaction export functionality with filtering options

### DIFF
--- a/backend/app/api/v1/endpoints/transactions.py
+++ b/backend/app/api/v1/endpoints/transactions.py
@@ -1,7 +1,10 @@
 from datetime import date, datetime
 from typing import Annotated
+import csv
+import io
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
+from fastapi.responses import StreamingResponse
 
 from app import crud, schemas
 from app.api import deps
@@ -58,6 +61,78 @@ def read_transactions(
         transactions = crud.transaction.get_by_user(db, user_id=current_user.id, skip=skip, limit=limit)
 
     return [schemas.TransactionRead.model_validate(txn) for txn in transactions]
+
+
+@router.get("/export", response_class=StreamingResponse)
+def export_transactions(
+    *,
+    db: DbSession,
+    category_id: int | None = None,
+    transaction_type: str | None = Query(default=None, pattern="^(income|expense)$"),
+    start_date: date | None = None,
+    end_date: date | None = None,
+    current_user: CurrentUser,
+) -> StreamingResponse:
+    logger.info(
+        f"User {current_user.id} is exporting transactions with filters - "
+        f"category_id: {category_id}, transaction_type: {transaction_type}, "
+        f"start_date: {start_date}, end_date: {end_date}"
+    )
+
+    transactions = crud.transaction.get_filtered_for_export(
+        db,
+        user_id=current_user.id,
+        category_id=category_id,
+        transaction_type=transaction_type,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    def iter_csv() -> list[str]:
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+
+        # Header row
+        writer.writerow(
+            [
+                "id",
+                "date",
+                "description",
+                "category_id",
+                "transaction_type",
+                "amount",
+                "account_name",
+                "bill_id",
+                "goal_id",
+            ]
+        )
+        yield buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate(0)
+
+        for txn in transactions:
+            writer.writerow(
+                [
+                    txn.id,
+                    txn.transaction_date.isoformat() if txn.transaction_date else "",
+                    txn.description or "",
+                    txn.category_id,
+                    txn.transaction_type,
+                    f"{txn.amount:.2f}" if txn.amount is not None else "",
+                    txn.account_name or "",
+                    txn.bill_id or "",
+                    txn.goal_id or "",
+                ]
+            )
+            yield buffer.getvalue()
+            buffer.seek(0)
+            buffer.truncate(0)
+
+    return StreamingResponse(
+        iter_csv(),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="transactions.csv"'},
+    )
 
 
 @router.post("/", response_model=schemas.TransactionRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/crud/crud_transaction.py
+++ b/backend/app/crud/crud_transaction.py
@@ -71,6 +71,30 @@ class CRUDTransaction(CRUDBase[Transactions, TransactionCreate, TransactionUpdat
         )
         return list(db.execute(stmt).scalars().all())
 
+    def get_filtered_for_export(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        category_id: int | None = None,
+        transaction_type: str | None = None,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[Transactions]:
+        stmt = select(Transactions).where(Transactions.user_id == user_id)
+
+        if category_id is not None:
+            stmt = stmt.where(Transactions.category_id == category_id)
+        if transaction_type is not None:
+            stmt = stmt.where(Transactions.transaction_type == transaction_type)
+        if start_date is not None:
+            stmt = stmt.where(Transactions.transaction_date >= start_date)
+        if end_date is not None:
+            stmt = stmt.where(Transactions.transaction_date <= end_date)
+
+        stmt = stmt.order_by(Transactions.transaction_date.desc())
+        return list(db.execute(stmt).scalars().all())
+
     def create(self, db: Session, *, obj_in: TransactionCreate, user_id: int) -> Transactions:
         db_obj = Transactions(
             user_id=user_id,

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -68,6 +68,10 @@ function Transactions() {
   const [search, setSearch] = useState('')
   const [sortKey, setSortKey] = useState<SortKey>('transaction_date')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+  const [filterCategoryId, setFilterCategoryId] = useState<number | 'all'>('all')
+  const [filterType, setFilterType] = useState<'all' | 'income' | 'expense'>('all')
+  const [filterStartDate, setFilterStartDate] = useState('')
+  const [filterEndDate, setFilterEndDate] = useState('')
 
   const [suggestion, setSuggestion] = useState<{
     category_id: number
@@ -101,9 +105,27 @@ function Transactions() {
     if (!token) return
     setIsLoadingTransactions(true)
     try {
-      const response = await fetch(`${apiUrl}/api/v1/transactions/`, {
-        headers: { Authorization: `Bearer ${token}` }
-      })
+      const params = new URLSearchParams()
+      if (filterCategoryId !== 'all') {
+        params.set('category_id', String(filterCategoryId))
+      }
+      if (filterType !== 'all') {
+        params.set('transaction_type', filterType)
+      }
+      if (filterStartDate) {
+        params.set('start_date', filterStartDate)
+      }
+      if (filterEndDate) {
+        params.set('end_date', filterEndDate)
+      }
+      const query = params.toString()
+
+      const response = await fetch(
+        `${apiUrl}/api/v1/transactions/${query ? `?${query}` : ''}`,
+        {
+          headers: { Authorization: `Bearer ${token}` }
+        }
+      )
       if (!response.ok) throw new Error('Failed to load transactions.')
       const data = (await response.json()) as Transaction[]
       setTransactions(data)
@@ -112,7 +134,54 @@ function Transactions() {
     } finally {
       setIsLoadingTransactions(false)
     }
-  }, [token])
+  }, [token, filterCategoryId, filterType, filterStartDate, filterEndDate])
+
+  const handleExportCsv = useCallback(async () => {
+    if (!token) {
+      setError('You must be logged in to export transactions.')
+      return
+    }
+
+    try {
+      const params = new URLSearchParams()
+      if (filterCategoryId !== 'all') {
+        params.set('category_id', String(filterCategoryId))
+      }
+      if (filterType !== 'all') {
+        params.set('transaction_type', filterType)
+      }
+      if (filterStartDate) {
+        params.set('start_date', filterStartDate)
+      }
+      if (filterEndDate) {
+        params.set('end_date', filterEndDate)
+      }
+      const query = params.toString()
+
+      const response = await fetch(
+        `${apiUrl}/api/v1/transactions/export${query ? `?${query}` : ''}`,
+        {
+          headers: { Authorization: `Bearer ${token}` }
+        }
+      )
+
+      if (!response.ok) {
+        throw new Error('Failed to export transactions.')
+      }
+
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'transactions.csv'
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      window.URL.revokeObjectURL(url)
+    } catch (exportError) {
+      setError(exportError instanceof Error ? exportError.message : 'Unknown error exporting transactions.')
+    }
+  }, [token, filterCategoryId, filterType, filterStartDate, filterEndDate])
 
   useEffect(() => {
     const loadCategories = async () => {
@@ -355,31 +424,94 @@ function Transactions() {
         Transactions
       </Typography>
 
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, gap: 2 }}>
-        <TextField
-          size="small"
-          placeholder="Search transactions..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          sx={{ flexGrow: 1 }}
-        />
-        <input
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          ref={fileInputRef}
-          style={{ display: 'none' }}
-          onChange={handleReceiptScan}
-        />
-        <Button
-          variant="outlined"
-          onClick={() => fileInputRef.current?.click()}
-          disabled={!token || scanLoading}
-        >
-          {scanLoading ? 'Scanning...' : 'Scan Receipt'}
-        </Button>
-        <Button variant="contained" onClick={() => setDialogOpen(true)} disabled={!token}>
-          + Add Transaction
-        </Button>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mb: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <TextField
+            size="small"
+            placeholder="Search transactions..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            sx={{ flexGrow: 1 }}
+          />
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            ref={fileInputRef}
+            style={{ display: 'none' }}
+            onChange={handleReceiptScan}
+          />
+          <Button
+            variant="outlined"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={!token || scanLoading}
+          >
+            {scanLoading ? 'Scanning...' : 'Scan Receipt'}
+          </Button>
+          <Button variant="contained" onClick={() => setDialogOpen(true)} disabled={!token}>
+            + Add Transaction
+          </Button>
+        </Box>
+
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="filter-category-label">Category</InputLabel>
+            <Select
+              labelId="filter-category-label"
+              label="Category"
+              value={filterCategoryId}
+              onChange={(e) =>
+                setFilterCategoryId(e.target.value === 'all' ? 'all' : Number(e.target.value))
+              }
+            >
+              <MenuItem value="all">All categories</MenuItem>
+              {categories.map((category) => (
+                <MenuItem key={category.id} value={category.id}>
+                  {category.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel id="filter-type-label">Type</InputLabel>
+            <Select
+              labelId="filter-type-label"
+              label="Type"
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value as 'all' | 'income' | 'expense')}
+            >
+              <MenuItem value="all">All types</MenuItem>
+              <MenuItem value="income">Income</MenuItem>
+              <MenuItem value="expense">Expense</MenuItem>
+            </Select>
+          </FormControl>
+
+          <TextField
+            label="Start date"
+            type="date"
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            value={filterStartDate}
+            onChange={(e) => setFilterStartDate(e.target.value)}
+          />
+          <TextField
+            label="End date"
+            type="date"
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            value={filterEndDate}
+            onChange={(e) => setFilterEndDate(e.target.value)}
+          />
+
+          <Box sx={{ flexGrow: 1 }} />
+
+          <Button variant="outlined" onClick={loadTransactions} disabled={!token || isLoadingTransactions}>
+            Apply filters
+          </Button>
+          <Button variant="contained" onClick={handleExportCsv} disabled={!token || isLoadingTransactions}>
+            Export CSV
+          </Button>
+        </Box>
       </Box>
 
       {!token && (


### PR DESCRIPTION
**Summary**

**Backend**

- Added get_filtered_for_export in crud_transaction to fetch a user’s transactions with optional filters: category_id, transaction_type, start_date, end_date.

- Introduced new endpoint GET /api/v1/transactions/export that returns a streamed CSV file with the authenticated user’s filtered transactions.

- CSV columns: id, date, description, category_id, transaction_type, amount, account_name, bill_id, goal_id.

**Frontend**

**On the Transactions page:**

- Added filters for Category, Type (income/expense), and date range (Start date / End date), which are sent to the backend when loading transactions.

- Added an “Export CSV” button that calls /api/v1/transactions/export using the same filters and triggers a transactions.csv download.

- Transaction list now loads using these filters, while keeping the existing text search and sorting.