### PR TITLE
Feature/pdf report generation

### DIFF
--- a/backend/app/api/v1/endpoints/analytics.py
+++ b/backend/app/api/v1/endpoints/analytics.py
@@ -1,13 +1,16 @@
 from datetime import datetime
+import io
 
 import pendulum
-from fastapi import APIRouter, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import extract, func, select
+from fastapi.responses import StreamingResponse
 
 from app import models
 from app.api.deps import CurrentUser, DbSession
 from app.core.logger_init import setup_logging
 from app.services.ml_service import compare_classifiers
+from app.services.report_service import generate_spending_report_pdf_bytes
 
 logger = setup_logging()
 router = APIRouter()
@@ -126,3 +129,59 @@ def get_monthly_spending_trend(
         ]
     }
     return result
+
+
+@router.get("/spending-report/pdf", response_class=StreamingResponse)
+def get_spending_report_pdf(
+    *,
+    db: DbSession,
+    report_type: str = Query(pattern="^(monthly|yearly)$"),
+    start_year: int | None = None,
+    start_month: int | None = None,
+    end_year: int | None = None,
+    end_month: int | None = None,
+    year: int | None = None,
+    current_user: CurrentUser,
+) -> StreamingResponse:
+    """
+    Download a PDF with spending summary + charts.
+
+    report_type:
+      - monthly: provide start_year/start_month/end_year/end_month
+      - yearly: provide year
+    """
+
+    if report_type == "monthly":
+        missing = [name for name, val in (
+            ("start_year", start_year),
+            ("start_month", start_month),
+            ("end_year", end_year),
+            ("end_month", end_month),
+        ) if val is None]
+        if missing:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Missing parameters for monthly report: {', '.join(missing)}")
+
+    if report_type == "yearly" and year is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Missing parameter 'year' for yearly report")
+
+    pdf_bytes = generate_spending_report_pdf_bytes(
+        db=db,
+        user_id=current_user.id,
+        report_type=report_type,
+        start_year=start_year,
+        start_month=start_month,
+        end_year=end_year,
+        end_month=end_month,
+        year=year,
+    )
+
+    if report_type == "monthly":
+        file_name = f"spending-report-monthly-{start_year}-{start_month}-to-{end_year}-{end_month}.pdf"
+    else:
+        file_name = f"spending-report-yearly-{year}.pdf"
+
+    return StreamingResponse(
+        io.BytesIO(pdf_bytes),
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
+    )

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -164,6 +164,8 @@ def _plot_category_pie(category_points: list[dict[str, Any]]) -> io.BytesIO:
             labels.append("Other")
             values.append(other_total)
 
+        legend_labels = [f"{name} — ${value:,.2f}" for name, value in zip(labels, values, strict=False)]
+
         total_value = sum(values)
 
         def _pct_fmt(pct: float) -> str:
@@ -180,7 +182,7 @@ def _plot_category_pie(category_points: list[dict[str, Any]]) -> io.BytesIO:
         )
         ax.legend(
             wedges,
-            labels,
+            legend_labels,
             title="Categories",
             loc="center left",
             bbox_to_anchor=(1.02, 0.5),

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1,0 +1,372 @@
+import io
+from dataclasses import dataclass
+from typing import Any
+
+import matplotlib
+matplotlib.use("Agg")  # Render charts server-side (no display required)
+import pendulum
+from matplotlib import pyplot as plt
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import Image, PageBreak, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+from sqlalchemy import extract, func, select
+
+from app import models
+
+
+@dataclass(frozen=True)
+class MonthlyPoint:
+    year: int
+    month: int
+    total: float
+
+
+def _fill_monthly_series(
+    *,
+    monthly_points: list[MonthlyPoint],
+    start_date,
+    end_date,
+) -> list[MonthlyPoint]:
+    totals_by_key = {(p.year, p.month): p.total for p in monthly_points}
+
+    # Iterate month-by-month so charts and tables have consistent X axes.
+    cursor = start_date.start_of("month")
+    end_cursor = end_date.start_of("month")
+
+    filled: list[MonthlyPoint] = []
+    while cursor <= end_cursor:
+        key = (cursor.year, cursor.month)
+        filled.append(MonthlyPoint(year=cursor.year, month=cursor.month, total=totals_by_key.get(key, 0.0)))
+        cursor = cursor.add(months=1)
+
+    return filled
+
+
+def _query_monthly_expenses(*, db, user_id: int, start_date, end_date) -> list[MonthlyPoint]:
+    stmt = (
+        select(
+            extract("year", models.Transactions.transaction_date).label("year"),
+            extract("month", models.Transactions.transaction_date).label("month"),
+            func.sum(models.Transactions.amount).label("total_amount"),
+        )
+        .join(models.Category, models.Transactions.category_id == models.Category.id)
+        .where(
+            models.Transactions.user_id == user_id,
+            models.Category.type == "expense",
+            models.Transactions.transaction_date >= start_date,
+            models.Transactions.transaction_date <= end_date,
+        )
+        .group_by(
+            extract("year", models.Transactions.transaction_date),
+            extract("month", models.Transactions.transaction_date),
+        )
+        .order_by(
+            extract("year", models.Transactions.transaction_date),
+            extract("month", models.Transactions.transaction_date),
+        )
+    )
+
+    rows = db.execute(stmt).all()
+    return [
+        MonthlyPoint(year=int(year), month=int(month), total=float(total) if total else 0.0)
+        for year, month, total in rows
+    ]
+
+
+def _query_category_distribution(*, db, user_id: int, start_date, end_date, top_n: int = 8) -> list[dict[str, Any]]:
+    stmt = (
+        select(
+            models.Category.name.label("category_name"),
+            func.sum(models.Transactions.amount).label("total_amount"),
+        )
+        .join(models.Category, models.Transactions.category_id == models.Category.id)
+        .where(
+            models.Transactions.user_id == user_id,
+            models.Category.type == "expense",
+            models.Transactions.transaction_date >= start_date,
+            models.Transactions.transaction_date <= end_date,
+        )
+        .group_by(models.Category.name)
+        .order_by(func.sum(models.Transactions.amount).desc())
+    )
+
+    rows = db.execute(stmt).all()
+
+    points: list[dict[str, Any]] = [
+        {"category": str(category_name), "total": float(total) if total else 0.0} for category_name, total in rows
+    ]
+    return points[:top_n]
+
+
+def _plot_line_monthly(monthly_points: list[MonthlyPoint]) -> io.BytesIO:
+    fig = plt.figure(figsize=(8, 3.5))
+    ax = fig.add_subplot(111)
+
+    if not monthly_points:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center")
+        ax.axis("off")
+    else:
+        labels = [f"{p.year}-{p.month:02d}" for p in monthly_points]
+        values = [p.total for p in monthly_points]
+        ax.plot(labels, values, marker="o", linewidth=2)
+        ax.set_title("Expenses by Month")
+        ax.set_ylabel("Total amount")
+        ax.grid(True, linestyle="--", alpha=0.4)
+        plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
+
+    fig.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=200)
+    plt.close(fig)
+    buf.seek(0)
+    return buf
+
+
+def _plot_bar_monthly(monthly_points: list[MonthlyPoint]) -> io.BytesIO:
+    fig = plt.figure(figsize=(8, 3.5))
+    ax = fig.add_subplot(111)
+
+    if not monthly_points:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center")
+        ax.axis("off")
+    else:
+        labels = [f"{p.month:02d}" for p in monthly_points]
+        values = [p.total for p in monthly_points]
+        ax.bar(labels, values, color="#e74c3c")
+        ax.set_title("Expenses by Month")
+        ax.set_xlabel("Month")
+        ax.set_ylabel("Total amount")
+        ax.grid(True, axis="y", linestyle="--", alpha=0.4)
+
+    fig.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=200)
+    plt.close(fig)
+    buf.seek(0)
+    return buf
+
+
+def _plot_category_pie(category_points: list[dict[str, Any]]) -> io.BytesIO:
+    fig = plt.figure(figsize=(6.4, 4.6))
+    ax = fig.add_subplot(111)
+
+    if not category_points:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center")
+        ax.axis("off")
+    else:
+        top = category_points[:8]
+        other_total = sum(p["total"] for p in category_points[8:]) if len(category_points) > 8 else 0.0
+        labels = [p["category"] for p in top]
+        values = [p["total"] for p in top]
+        if other_total > 0:
+            labels.append("Other")
+            values.append(other_total)
+
+        total_value = sum(values)
+
+        def _pct_fmt(pct: float) -> str:
+            # Hide tiny percentages to reduce overlap noise.
+            return f"{pct:.1f}%" if pct >= 3 else ""
+
+        wedges, _texts, _autotexts = ax.pie(
+            values,
+            labels=None,  # labels are shown in the legend to avoid overlap
+            autopct=_pct_fmt if total_value > 0 else None,
+            startangle=90,
+            pctdistance=0.72,
+            textprops={"fontsize": 9},
+        )
+        ax.legend(
+            wedges,
+            labels,
+            title="Categories",
+            loc="center left",
+            bbox_to_anchor=(1.02, 0.5),
+            fontsize=9,
+            title_fontsize=10,
+            frameon=False,
+        )
+        ax.axis("equal")
+        fig.subplots_adjust(right=0.75)
+
+    fig.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=200)
+    plt.close(fig)
+    buf.seek(0)
+    return buf
+
+
+def generate_spending_report_pdf_bytes(
+    *,
+    db,
+    user_id: int,
+    report_type: str,
+    start_year: int | None = None,
+    start_month: int | None = None,
+    end_year: int | None = None,
+    end_month: int | None = None,
+    year: int | None = None,
+) -> bytes:
+    if report_type not in {"monthly", "yearly"}:
+        raise ValueError("report_type must be 'monthly' or 'yearly'")
+
+    if report_type == "monthly":
+        if start_year is None or start_month is None or end_year is None or end_month is None:
+            raise ValueError("start_year/start_month/end_year/end_month are required for monthly reports")
+
+        start_date = pendulum.datetime(start_year, start_month, 1)
+        end_date = pendulum.datetime(end_year, end_month, 1).end_of("month")
+    else:
+        if year is None:
+            raise ValueError("year is required for yearly reports")
+
+        start_date = pendulum.datetime(year, 1, 1)
+        end_date = pendulum.datetime(year, 12, 1).end_of("month")
+
+    monthly_points = _query_monthly_expenses(
+        db=db,
+        user_id=user_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    monthly_points = _fill_monthly_series(monthly_points=monthly_points, start_date=start_date, end_date=end_date)
+
+    total_spent = sum(p.total for p in monthly_points)
+    avg_monthly = total_spent / len(monthly_points) if monthly_points else 0.0
+    top_month = max(monthly_points, key=lambda p: p.total) if monthly_points else None
+
+    # Query a bit more than the visible pie slices so we can group the rest as "Other".
+    category_points_top = _query_category_distribution(
+        db=db,
+        user_id=user_id,
+        start_date=start_date,
+        end_date=end_date,
+        top_n=20,
+    )
+
+    pie_points: list[dict[str, Any]] = category_points_top
+
+    if report_type == "yearly":
+        chart_img = _plot_bar_monthly(monthly_points)
+        chart_title = "Yearly Spending Summary"
+    else:
+        chart_img = _plot_line_monthly(monthly_points)
+        chart_title = "Monthly Spending Summary"
+
+    pie_img = _plot_category_pie(pie_points)
+
+    # Build PDF
+    pdf_buffer = io.BytesIO()
+    doc = SimpleDocTemplate(pdf_buffer, pagesize=A4, rightMargin=36, leftMargin=36, topMargin=36, bottomMargin=36)
+    styles = getSampleStyleSheet()
+
+    if report_type == "yearly":
+        report_label = f"Year {year}"
+        range_label = f"{start_date.format('YYYY-MM-DD')} to {end_date.format('YYYY-MM-DD')}"
+    else:
+        report_label = f"{start_year:04d}-{start_month:02d} to {end_year:04d}-{end_month:02d}"
+        range_label = f"{start_date.format('YYYY-MM-DD')} to {end_date.format('YYYY-MM-DD')}"
+
+    story: list[Any] = []
+    story.append(Paragraph("Spending Report", styles["Title"]))
+    story.append(Spacer(1, 8))
+    story.append(Paragraph(report_label, styles["Heading2"]))
+    story.append(Spacer(1, 6))
+    story.append(Paragraph(f"Range: {range_label}", styles["BodyText"]))
+    story.append(Spacer(1, 14))
+
+    summary_table_data = [
+        ["Total spent", f"${total_spent:,.2f}"],
+        ["Average / month", f"${avg_monthly:,.2f}"],
+        ["Top month", f"{top_month.year}-{top_month.month:02d} (${top_month.total:,.2f})" if top_month else "—"],
+    ]
+
+    summary_table = Table(summary_table_data, colWidths=[2.1 * inch, 2.4 * inch])
+    summary_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
+                ("TEXTCOLOR", (0, 0), (-1, -1), colors.black),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.lightgrey),
+                ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
+                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("ROWBACKGROUNDS", (0, 0), (-1, -1), [colors.white, colors.lightgrey]),
+            ]
+        )
+    )
+
+    story.append(Paragraph(chart_title, styles["Heading2"]))
+    story.append(Spacer(1, 6))
+    story.append(summary_table)
+    story.append(Spacer(1, 12))
+
+    # Monthly breakdown table (useful even when the chart is present).
+    # Limit to keep PDF readable for wider ranges.
+    max_rows = 24
+    months_to_show = monthly_points
+    if len(monthly_points) > max_rows:
+        months_to_show = monthly_points[-max_rows:]
+
+    month_table_data = [["Month", "Total"]]
+    for p in months_to_show:
+        month_table_data.append([f"{p.year}-{p.month:02d}", f"${p.total:,.2f}"])
+    month_table_data = (
+        month_table_data
+        if len(monthly_points) <= max_rows
+        else month_table_data + [["…", "…"]]
+    )
+
+    month_table = Table(month_table_data, colWidths=[3.0 * inch, 2.0 * inch])
+    month_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.lightgrey),
+                ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("ROWBACKGROUNDS", (0, 0), (-1, -1), [colors.white, colors.lightgrey]),
+            ]
+        )
+    )
+    story.append(month_table)
+    story.append(Spacer(1, 18))
+
+    # Chart image (line/bar)
+    # reportlab Image can render directly from an in-memory file-like object (BytesIO).
+    chart_flow = Image(chart_img, width=7.4 * inch, height=3.3 * inch)
+    story.append(chart_flow)
+    story.append(Spacer(1, 18))
+
+    # Pie chart for categories starts on a new page to keep layout clean.
+    story.append(PageBreak())
+    story.append(Paragraph("Spending by Category", styles["Heading2"]))
+    story.append(Spacer(1, 6))
+    pie_flow = Image(pie_img, width=6.8 * inch, height=4.8 * inch)
+    story.append(pie_flow)
+    story.append(Spacer(1, 10))
+
+    if category_points_top:
+        top_rows = [[p["category"], f"${p['total']:,.2f}"] for p in category_points_top[:5]]
+        top_table = Table([["Top categories", "Amount"]] + top_rows, colWidths=[3.4 * inch, 1.8 * inch])
+        top_table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.lightgrey),
+                    ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 10),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ]
+            )
+        )
+        story.append(top_table)
+
+    doc.build(story)
+    pdf_buffer.seek(0)
+    return pdf_buffer.getvalue()
+

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,12 +1,66 @@
 import { useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
-import { Alert, Box, Button, Container, Typography } from '@mui/material'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Typography
+} from '@mui/material'
 import TrendLineGraph from '../components/charts/TrendLineGraph'
 import SpendingPieChart from '../components/charts/SpendingPieChart'
 import BudgetVsActual from '../components/charts/BudgetVsActual'
 
 function Analytics() {
   const [token] = useState(() => localStorage.getItem('access_token') || '')
+  const [pdfLoading, setPdfLoading] = useState(false)
+  const [pdfError, setPdfError] = useState<string | null>(null)
+
+  const [monthlyRange, setMonthlyRange] = useState<3 | 6 | 12>(6)
+  const currentYear = new Date().getFullYear()
+  const [year, setYear] = useState<number>(currentYear)
+
+  const getLastNMonthsRange = (n: 3 | 6 | 12) => {
+    const now = new Date()
+    const endYear = now.getFullYear()
+    const endMonth = now.getMonth() + 1
+    const startDate = new Date(now.getFullYear(), now.getMonth() - (n - 1), 1)
+    const startYear = startDate.getFullYear()
+    const startMonth = startDate.getMonth() + 1
+    return { startYear, startMonth, endYear, endMonth }
+  }
+
+  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+  const downloadPdf = async (url: string, filename: string) => {
+    setPdfLoading(true)
+    setPdfError(null)
+    try {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      if (!res.ok) throw new Error('Failed to generate PDF report.')
+      const blob = await res.blob()
+      const objectUrl = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = objectUrl
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      window.URL.revokeObjectURL(objectUrl)
+    } catch (err) {
+      setPdfError(err instanceof Error ? err.message : 'Unknown error generating PDF.')
+    } finally {
+      setPdfLoading(false)
+    }
+  }
 
   return (
     <Container maxWidth="lg" sx={{ py: 6 }}>
@@ -34,6 +88,79 @@ function Analytics() {
             </Box>
           </Box>
           <BudgetVsActual token={token} />
+
+          <Paper sx={{ p: 3 }}>
+            <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+              PDF Reports (Spending)
+            </Typography>
+
+            {pdfError && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {pdfError}
+              </Alert>
+            )}
+
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
+              <FormControl size="small" sx={{ minWidth: 220 }}>
+                <InputLabel id="monthly-range-label">Monthly range</InputLabel>
+                <Select
+                  labelId="monthly-range-label"
+                  label="Monthly range"
+                  value={monthlyRange}
+                  onChange={(e) => setMonthlyRange(e.target.value as 3 | 6 | 12)}
+                  disabled={pdfLoading}
+                >
+                  <MenuItem value={3}>Last 3 months</MenuItem>
+                  <MenuItem value={6}>Last 6 months</MenuItem>
+                  <MenuItem value={12}>Last 12 months</MenuItem>
+                </Select>
+              </FormControl>
+
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  const { startYear, startMonth, endYear, endMonth } = getLastNMonthsRange(monthlyRange)
+                  const url = `${apiUrl}/api/v1/analytics/spending-report/pdf?report_type=monthly&start_year=${startYear}&start_month=${startMonth}&end_year=${endYear}&end_month=${endMonth}`
+                  const filename = `spending-report-monthly-${startYear}-${String(startMonth).padStart(2, '0')}-to-${endYear}-${String(endMonth).padStart(2, '0')}.pdf`
+                  void downloadPdf(url, filename)
+                }}
+                disabled={!token || pdfLoading}
+                sx={{ height: 40 }}
+              >
+                {pdfLoading ? <CircularProgress size={18} /> : 'Download Monthly PDF'}
+              </Button>
+
+              <FormControl size="small" sx={{ minWidth: 180 }}>
+                <InputLabel id="year-label">Year</InputLabel>
+                <Select
+                  labelId="year-label"
+                  label="Year"
+                  value={year}
+                  onChange={(e) => setYear(Number(e.target.value))}
+                  disabled={pdfLoading}
+                >
+                  {Array.from({ length: 6 }, (_, i) => currentYear - i).map((y) => (
+                    <MenuItem key={y} value={y}>
+                      {y}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <Button
+                variant="contained"
+                onClick={() => {
+                  const url = `${apiUrl}/api/v1/analytics/spending-report/pdf?report_type=yearly&year=${year}`
+                  const filename = `spending-report-yearly-${year}.pdf`
+                  void downloadPdf(url, filename)
+                }}
+                disabled={!token || pdfLoading}
+                sx={{ height: 40 }}
+              >
+                {pdfLoading ? <CircularProgress size={18} /> : 'Download Yearly PDF'}
+              </Button>
+            </Box>
+          </Paper>
         </Box>
       )}
     </Container>


### PR DESCRIPTION
This PR adds monthly/yearly PDF spending reports with summaries and charts, available from both backend and frontend.

**What changed**

**

> Backend

**

- New endpoint: GET /api/v1/analytics/spending-report/pdf

**Supports**:

- report_type=monthly + start_year, start_month, end_year, end_month

- report_type=yearly + year

**Generates PDF with**:

- spending summary
- monthly trend chart
- category pie chart
- breakdown tables
- Improved PDF layout/readability (fixed chart label overlap, cleaner page split, better category legend).

**

> Frontend

**

- Added a PDF Reports (Spending) section in Analytics.

**New buttons**:

- Download Monthly PDF (last 3/6/12 months)
- Download Yearly PDF (selected year)

**Quick test plan**

1. **Frontend**

- Go to http://localhost:5173/analytics
- Download both monthly and yearly reports
- Confirm files open correctly and charts/tables look readable

1. **Backend (Swagger)**

- Open http://localhost:8000/docs
- Authorize with Bearer token
- Call GET /api/v1/analytics/spending-report/pdf with:
- monthly params or yearly params
- Confirm 200 response and valid PDF download