### PR TITLE
refactor: move db init to FastAPI lifespan handler

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -10,19 +12,22 @@ from app.db.session import engine, get_session
 
 logger = setup_logging()
 
-# Create database tables
-Base.metadata.create_all(bind=engine)
-logger.info("Database tables created.")
 
-# Initialize database with predefined data
-with get_session() as db:
-    init_db(db)
-    init_superuser(db)
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    Base.metadata.create_all(bind=engine)
+    logger.info("Database tables created.")
+    with get_session() as db:
+        init_db(db)
+        init_superuser(db)
+    yield
+
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
     version=settings.VERSION,
-    openapi_url=f"{settings.API_V1_STR}/openapi.json"
+    openapi_url=f"{settings.API_V1_STR}/openapi.json",
+    lifespan=lifespan,
 )
 
 # Set up CORS


### PR DESCRIPTION
## Summary
- Moves `Base.metadata.create_all()`, `init_db()`, and `init_superuser()` into a FastAPI `lifespan` context manager
- Fixes startup race condition where SQLAlchemy attempted a DB connection before the database container was ready

## Why
The previous module-level startup code ran at import time, before Docker's `depends_on: service_healthy` check could take effect. This caused the backend to crash with a DNS resolution error (`could not translate host name "db"`) on fresh starts.

## Test plan
- [ ] Run `docker-compose down && docker-compose up -d` and confirm backend starts without errors
- [ ] Verify `/health` endpoint responds after startup
- [ ] Confirm DB tables are created and seed data is present